### PR TITLE
[bugfix] `find_viable_combinations` raises error if no viable_combinations

### DIFF
--- a/src/agora/helper.py
+++ b/src/agora/helper.py
@@ -61,7 +61,7 @@ def find_viable_combinations(
     }
 
     if not viable_combinations:
-        raise InsufficientFundsError(f"Insufficient funds for transaction of {target_price}")
+        return []
 
     return sorted(viable_combinations, key=lambda combo: combo[0], reverse=True)
 

--- a/unit_tests/src/agora/test_helper.py
+++ b/unit_tests/src/agora/test_helper.py
@@ -1,0 +1,32 @@
+from decimal import Decimal
+
+import pytest
+
+import agora.helper as helper
+
+
+@pytest.fixture(scope="session")
+def wallet() -> list[Decimal]:
+    money: dict[str, int] = {
+        "100": 1,
+        "20": 4,
+        "10": 2,
+        "1": 5,
+        "0.25": 1,
+        "0.10": 6,
+        "0.05": 3,
+    }
+    return helper.populate_wallet(money)
+
+
+@pytest.mark.parametrize(
+    "price, picks, expected",
+    [
+        (Decimal("15.05"), 2, 13),
+        (Decimal("150.05"), 2, 0),
+    ],
+)
+def test_path_validation(wallet, price, picks, expected):
+    all_paths = len(helper.find_viable_combinations(wallet, picks, price))
+
+    assert all_paths == expected, f"Expected {expected}, but got {all_paths}"


### PR DESCRIPTION
This pull request includes a bugfix in `src/agora/helper.py` and adds related unit tests to prevent similar future occurrences.

### BugFix

* Modified the `find_viable_combinations` function in `src/agora/helper.py` to return an empty list instead of raising an `InsufficientFundsError` when no viable combinations are found.

### Test coverage

* Added a new test file `unit_tests/src/agora/test_helper.py` with a fixture to populate the wallet and parameterized tests to validate the behavior of `find_viable_combinations`.