### PR TITLE
classmethod to create child nodes

### DIFF
--- a/src/agora/models.py
+++ b/src/agora/models.py
@@ -17,6 +17,16 @@ class Node:
         if self.balance < 0:
             self.return_change()
 
+    @classmethod
+    def create_child(cls, ccy: Decimal, node: "Node") -> "Node":
+        return cls(
+            name=str(ccy),
+            wallet=node.pick_from_wallet(ccy),
+            balance=node.balance - ccy,
+            path=node.path + [ccy],
+            cost=node.cost + 1,
+        )
+
     @property
     def wallet_hash(self) -> tuple[Decimal, ...]:
         return tuple(self.wallet)

--- a/src/agora/solutions/bfs.py
+++ b/src/agora/solutions/bfs.py
@@ -18,10 +18,10 @@ def bfs_factory(wallet: list[Decimal], price: Decimal) -> Callable[[], tuple[lis
 
     def breadth_first_search() -> tuple[list[Decimal], int]:
         nonlocal shortest_path, least_cost
+        queue: deque = deque()
+        visited: set[tuple[Decimal, ...]] = set()
 
         root = Node(name="root", wallet=wallet, balance=price, path=[], cost=0)
-        visited: set[tuple[Decimal, ...]] = set()
-        queue: deque = deque()
 
         queue.append(root)
         visited.add(root.wallet_hash)
@@ -33,19 +33,12 @@ def bfs_factory(wallet: list[Decimal], price: Decimal) -> Callable[[], tuple[lis
                 continue
 
             if current.balance == 0:
-                shortest_path = current.path
                 least_cost = current.cost
+                shortest_path = current.path
                 continue
 
             for ccy in current.denominations:
-
-                node = Node(
-                    name=str(ccy),
-                    wallet=current.pick_from_wallet(ccy),
-                    balance=current.balance - ccy,
-                    path=current.path + [ccy],
-                    cost=current.cost + 1,
-                )
+                node = Node.create_child(ccy, current)
 
                 if node.wallet_hash in visited:
                     continue


### PR DESCRIPTION
This pull request includes changes to improve the `Node` class and the breadth-first search algorithm in the `agora` module. The most important changes include the addition of a new class method to the `Node` class, refactoring of the breadth-first search function, and reordering of certain operations for clarity.

### Improvements to the `Node` class:

* [`src/agora/models.py`](diffhunk://#diff-6babae6b0b660eec128ef1c5a60aa08e18153d9c4b69cb99debea80233a1ae2aR20-R29): Added a new `create_child` class method to the `Node` class for creating child nodes more cleanly and concisely.

### Refactoring of the breadth-first search algorithm:

* [`src/agora/solutions/bfs.py`](diffhunk://#diff-85628a93aa6476191843fd5ee82bbf62a402e7ba4decf93ad10df0de2e6f9457R21-L24): Moved the initialization of `queue` and `visited` to the beginning of the `breadth_first_search` function for better readability.
* [`src/agora/solutions/bfs.py`](diffhunk://#diff-85628a93aa6476191843fd5ee82bbf62a402e7ba4decf93ad10df0de2e6f9457L36-R41): Reordered the assignment of `shortest_path` and `least_cost` to ensure the shortest path is set before continuing.
* [`src/agora/solutions/bfs.py`](diffhunk://#diff-85628a93aa6476191843fd5ee82bbf62a402e7ba4decf93ad10df0de2e6f9457L36-R41): Refactored the creation of child nodes within the `breadth_first_search` function to use the new `Node.create_child` method, simplifying the code.