### PR TITLE
delineate parent/child nodes

### DIFF
--- a/src/agora/models.py
+++ b/src/agora/models.py
@@ -18,17 +18,17 @@ class Node:
             self.return_change()
 
     @classmethod
-    def create_child(cls, ccy: Decimal, node: "Node") -> "Node":
+    def create_child(cls, denomination: Decimal, parent: "Node") -> "Node":
         return cls(
-            name=str(ccy),
-            wallet=node.pick_from_wallet(ccy),
-            balance=node.balance - ccy,
-            path=node.path + [ccy],
-            cost=node.cost + 1,
+            name=str(denomination),
+            wallet=parent.pick_from_wallet(denomination),
+            balance=parent.balance - denomination,
+            path=parent.path + [denomination],
+            cost=parent.cost + 1,
         )
 
     @property
-    def wallet_hash(self) -> tuple[Decimal, ...]:
+    def hash(self) -> tuple[Decimal, ...]:
         return tuple(self.wallet)
 
     @property

--- a/src/agora/solutions/bfs.py
+++ b/src/agora/solutions/bfs.py
@@ -24,27 +24,27 @@ def bfs_factory(wallet: list[Decimal], price: Decimal) -> Callable[[], tuple[lis
         root = Node(name="root", wallet=wallet, balance=price, path=[], cost=0)
 
         queue.append(root)
-        visited.add(root.wallet_hash)
+        visited.add(root.hash)
 
         while queue:
-            current: Node = queue.popleft()
+            parent: Node = queue.popleft()
 
-            if current.cost >= least_cost:
+            if parent.cost >= least_cost:
                 continue
 
-            if current.balance == 0:
-                least_cost = current.cost
-                shortest_path = current.path
+            if parent.balance == 0:
+                least_cost = parent.cost
+                shortest_path = parent.path
                 continue
 
-            for ccy in current.denominations:
-                node = Node.create_child(ccy, current)
+            for currency in parent.denominations:
+                child = Node.create_child(currency, parent)
 
-                if node.wallet_hash in visited:
+                if child.hash in visited:
                     continue
 
-                queue.append(node)
-                visited.add(node.wallet_hash)
+                queue.append(child)
+                visited.add(child.hash)
 
         return shortest_path, least_cost
 

--- a/unit_tests/src/agora/test_models.py
+++ b/unit_tests/src/agora/test_models.py
@@ -28,10 +28,10 @@ def test_wallet_order(wallet, expected):
     assert node.wallet == expected, "Wallet improperly sorted"
 
 
-def test_wallet_hash():
+def test_hash():
     wallet = [Decimal("1"), Decimal("2"), Decimal("3")]
     node = Node(name="test", wallet=wallet, balance=Decimal("0"), path=[], cost=0)
-    assert node.wallet_hash == (Decimal("3"), Decimal("2"), Decimal("1")), "Wallet hash mismatch"
+    assert node.hash == (Decimal("3"), Decimal("2"), Decimal("1")), "Wallet hash mismatch"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request includes several changes to the `Node` class and related functions in the `agora` project to improve naming consistency and clarity. The most important changes include renaming parameters and variables, as well as updating method names for better readability.

Changes to `Node` class and related functions:

* [`src/agora/models.py`](diffhunk://#diff-6babae6b0b660eec128ef1c5a60aa08e18153d9c4b69cb99debea80233a1ae2aL21-R31): Renamed the `ccy` parameter to `denomination`, `node` to `parent`, and the `wallet_hash` method to `hash` in the `create_child` method.
* [`src/agora/solutions/bfs.py`](diffhunk://#diff-85628a93aa6476191843fd5ee82bbf62a402e7ba4decf93ad10df0de2e6f9457L27-R47): Updated the `breadth_first_search` function to use the new `hash` method and renamed variables from `current` to `parent` and `ccy` to `currency`.
* [`unit_tests/src/agora/test_models.py`](diffhunk://#diff-0f10be2f792d011c07e7b23b6a2d335f09d37ecb57c3ca0fa9a06889931e85e9L31-R34): Renamed the `test_wallet_hash` function to `test_hash` to match the updated method name in the `Node` class.