### PR TITLE
preliminary regression tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,1 +1,4 @@
-[mypy]
+[pytest]
+markers =
+    smoke: marks tests as smoke tests
+    regression: marks tests as regression tests

--- a/unit_tests/src/agora/solutions/test_bfs.py
+++ b/unit_tests/src/agora/solutions/test_bfs.py
@@ -1,0 +1,42 @@
+from decimal import Decimal
+
+import pytest
+
+import agora.helpers as helpers
+from agora.solutions.bfs import bfs_factory
+
+
+@pytest.fixture(scope="session")
+def wallet() -> list[Decimal]:
+    money: dict[str, int] = {
+        "100": 10,
+        "20": 4,
+        "10": 2,
+        "1": 5,
+        "0.25": 1,
+        "0.10": 6,
+        "0.05": 3,
+        "0.01": 5,
+    }
+    return helpers.populate_wallet(money)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "price, expected",
+    [
+        (
+            Decimal("15.05"),
+            [Decimal("0.05"), Decimal("20"), Decimal("5.00")],
+        ),
+        (
+            Decimal("105.06"),
+            [Decimal("100"), Decimal("0.05"), Decimal("0.01"), Decimal("10"), Decimal("5.00")],
+        ),
+        (Decimal("150.05"), [Decimal("100"), Decimal("0.05"), Decimal("100"), Decimal("50.00")]),
+    ],
+    ids=["Price: $15.05", "Price: 105.06", "Price: $150.05"],
+)
+def test_bfs(wallet, price, expected):
+    result = bfs_factory(wallet, price)()
+    assert result == (expected, len(expected)), f"Expected {expected}, but got {result}"

--- a/unit_tests/src/agora/solutions/test_naive.py
+++ b/unit_tests/src/agora/solutions/test_naive.py
@@ -1,0 +1,45 @@
+from decimal import Decimal
+
+import pytest
+
+import agora.helpers as helpers
+from agora.solutions.naive import naive_factory
+
+
+@pytest.fixture(scope="session")
+def wallet() -> list[Decimal]:
+    money: dict[str, int] = {
+        "100": 10,
+        "20": 4,
+        "10": 2,
+        "1": 5,
+        "0.25": 1,
+        "0.10": 6,
+        "0.05": 3,
+        "0.01": 5,
+    }
+    return helpers.populate_wallet(money)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "price, expected",
+    [
+        (
+            Decimal("15.05"),
+            ((Decimal("20"), Decimal("0.05")), [Decimal("5.00")]),
+        ),
+        (
+            Decimal("105.06"),
+            ((Decimal("100"), Decimal("10"), Decimal("0.05"), Decimal("0.01")), [Decimal("5.00")]),
+        ),
+        (
+            Decimal("150.05"),
+            ((Decimal("100"), Decimal("100"), Decimal("0.05")), [Decimal("50.00")]),
+        ),
+    ],
+    ids=["Price: $15.05", "Price: 105.06", "Price: $150.05"],
+)
+def test_naive(wallet, price, expected):
+    result = naive_factory(wallet, price)()
+    assert result == expected, f"Expected {expected}, but got {result}"


### PR DESCRIPTION
This pull request includes updates to the testing framework configuration and enhancements to the breadth-first search (BFS) and naive solution tests. The most important changes involve adding pytest markers, updating the BFS price value, and introducing new regression tests for both BFS and naive solutions.

### `pytest.ini`:

* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1L1-R4): Added pytest markers for smoke and regression tests.

### BFS regression test:

* [`unit_tests/src/agora/solutions/test_bfs.py`](diffhunk://#diff-58d4694ebc6848bc753f398dad0dc8f702aa98a15f8880aefeb3279295e4329aR1-R42): Added regression tests for the BFS solution with various price values and expected results.

### Naive regression test:

* [`unit_tests/src/agora/solutions/test_naive.py`](diffhunk://#diff-78320c24c057f8e8a0e31b12c164f4780623ede843db888a47714cb3d6ad6bbbR1-R45): Added regression tests for the naive solution with various price values and expected results.